### PR TITLE
 Deprecated elements should have both the annotation and the Javadoc tag

### DIFF
--- a/breakerbox-azure/src/main/java/com/yammer/breakerbox/azure/model/DependencyEntity.java
+++ b/breakerbox-azure/src/main/java/com/yammer/breakerbox/azure/model/DependencyEntity.java
@@ -133,6 +133,7 @@ public class DependencyEntity extends TableType implements TableKey {
     }
 
     /**
+     * @deprecated kept for backward compatibility
      * For Azure bean serialization via reflection
      */
 
@@ -141,21 +142,37 @@ public class DependencyEntity extends TableType implements TableKey {
         super(TableId.DEPENDENCY);
     }
 
+    /**
+     * @deprecated kept for backward compatibility
+     * @return
+     */
     @Deprecated
     public String getTenacityConfigurationAsString() {
         return tenacityConfigurationAsString;
     }
 
+    /**
+     * @deprecated kept for backward compatibility
+     * @param tenacityConfigurationAsString
+     */
     @Deprecated
     public void setTenacityConfigurationAsString(String tenacityConfigurationAsString) {
         this.tenacityConfigurationAsString = tenacityConfigurationAsString;
     }
 
+    /**
+     * @deprecated kept for backward compatibility
+     * @return
+     */
     @Deprecated
     public String getServiceName() {
         return serviceName;
     }
 
+    /**
+     * @deprecated kept for backward compatibility
+     * @param serviceName
+     */
     @Deprecated
     public void setServiceName(String serviceName) {
         this.serviceName = serviceName;
@@ -169,6 +186,10 @@ public class DependencyEntity extends TableType implements TableKey {
         return user;
     }
 
+    /**
+     * @deprecated kept for backward compatibility
+     * @param user
+     */
     @Deprecated
     public void setUser(String user) {
         this.user = user;

--- a/breakerbox-azure/src/main/java/com/yammer/breakerbox/azure/model/ServiceEntity.java
+++ b/breakerbox-azure/src/main/java/com/yammer/breakerbox/azure/model/ServiceEntity.java
@@ -62,7 +62,10 @@ public class ServiceEntity extends TableType implements TableKey {
         return TableId.SERVICE;
     }
 
-    /** For Azure */
+    /**
+     * @deprecated kept for backward compatibility
+     * For Azure 
+     */
 
     @Deprecated
     public ServiceEntity() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:MissingDeprecatedCheck - “ Deprecated elements should have both the annotation and the Javadoc tag ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:MissingDeprecatedCheck
Please let me know if you have any questions.
Ayman Abdelghany.