### PR TITLE
Instance discovery in Kubernetes clusters

### DIFF
--- a/breakerbox-service/pom.xml
+++ b/breakerbox-service/pom.xml
@@ -55,10 +55,17 @@
             <groupId>com.netflix.turbine</groupId>
             <artifactId>turbine-core</artifactId>
         </dependency>
+        <!-- Allows breakerbox in a Kubernetes cluster to discover instances -->
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-api</artifactId>
             <version>2.2.136</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.module</groupId>
+                    <artifactId>jackson-module-jaxb-annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/breakerbox-service/pom.xml
+++ b/breakerbox-service/pom.xml
@@ -55,6 +55,11 @@
             <groupId>com.netflix.turbine</groupId>
             <artifactId>turbine-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-api</artifactId>
+            <version>2.2.136</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/breakerbox-service/src/main/java/com/yammer/breakerbox/service/turbine/KubernetesInstanceDiscovery.java
+++ b/breakerbox-service/src/main/java/com/yammer/breakerbox/service/turbine/KubernetesInstanceDiscovery.java
@@ -14,8 +14,8 @@ import java.util.stream.Collectors;
 
 /**
  * Discovers instances in a Kubernetes cluster. The idea is to
- * find ReplicationControllers or ReplicaSets, check if their instances
- * are running Tenacity and return a list of valid instances.
+ * find pods with the 'breakerbox-port' annotation and use their
+ * base names in combination with the namespace to build Hystrix clusters.
  */
 public class KubernetesInstanceDiscovery implements InstanceDiscovery {
 

--- a/breakerbox-service/src/main/java/com/yammer/breakerbox/service/turbine/KubernetesInstanceDiscovery.java
+++ b/breakerbox-service/src/main/java/com/yammer/breakerbox/service/turbine/KubernetesInstanceDiscovery.java
@@ -1,0 +1,40 @@
+package com.yammer.breakerbox.service.turbine;
+
+
+import com.netflix.turbine.discovery.Instance;
+import com.netflix.turbine.discovery.InstanceDiscovery;
+import io.fabric8.kubernetes.api.model.ReplicationController;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Discovers instances in a Kubernetes cluster. The idea is to
+ * find ReplicationControllers or ReplicaSets, check if their instances
+ * are running Tenacity and return a list of valid instances.
+ */
+public class KubernetesInstanceDiscovery implements InstanceDiscovery {
+
+    private final KubernetesClient client;
+
+    public KubernetesInstanceDiscovery() {
+        this.client = new DefaultKubernetesClient();
+    }
+
+    public KubernetesInstanceDiscovery(KubernetesClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public Collection<Instance> getInstanceList() throws Exception {
+        List<ReplicationController> controllers = client.replicationControllers().list().getItems();
+        return controllers.stream().map(c -> {
+            String validName = c.getMetadata().getName().toLowerCase().replace(" ", "-");
+            String cluster = String.format("%s-%s", c.getMetadata().getNamespace(), validName);
+            return new Instance("host", cluster, true);
+        }).collect(Collectors.toList());
+    }
+}

--- a/breakerbox-service/src/test/java/com/yammer/breakerbox/service/turbine/tests/KubernetesInstanceDiscoveryTest.java
+++ b/breakerbox-service/src/test/java/com/yammer/breakerbox/service/turbine/tests/KubernetesInstanceDiscoveryTest.java
@@ -1,0 +1,67 @@
+package com.yammer.breakerbox.service.turbine.tests;
+
+import com.google.common.collect.Lists;
+import com.netflix.turbine.discovery.Instance;
+import com.yammer.breakerbox.service.turbine.KubernetesInstanceDiscovery;
+import io.fabric8.kubernetes.api.model.DoneableReplicationController;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ReplicationController;
+import io.fabric8.kubernetes.api.model.ReplicationControllerList;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.dsl.ClientMixedOperation;
+import io.fabric8.kubernetes.client.dsl.ClientRollableScallableResource;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.mockito.Mockito.stub;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KubernetesInstanceDiscoveryTest {
+
+    @Mock DefaultKubernetesClient client;
+    @Mock ClientMixedOperation<
+            ReplicationController,
+            ReplicationControllerList,
+            DoneableReplicationController,
+            ClientRollableScallableResource<ReplicationController, DoneableReplicationController>> controllers;
+    @Mock ReplicationControllerList controllerList;
+
+    private KubernetesInstanceDiscovery discovery;
+
+    @Before
+    public void setupDiscovery() {
+        ReplicationController serviceA = new ReplicationController();
+        serviceA.setMetadata(new ObjectMeta());
+        serviceA.getMetadata().setName("Service A");
+        serviceA.getMetadata().setNamespace("staging");
+        ReplicationController serviceB = new ReplicationController();
+        serviceB.setMetadata(new ObjectMeta());
+        serviceB.getMetadata().setName("Service B");
+        serviceB.getMetadata().setNamespace("production");
+        List<ReplicationController> list = Lists.newArrayList(serviceA, serviceB);
+
+        stub(client.replicationControllers()).toReturn(controllers);
+        stub(controllers.list()).toReturn(controllerList);
+        stub(controllerList.getItems()).toReturn(list);
+        this.discovery = new KubernetesInstanceDiscovery(client);
+    }
+
+    @Test
+    public void usesControllerNamesToBuildClusters() throws Exception {
+        Collection<Instance> instances = discovery.getInstanceList();
+        for (Instance instance: instances) {
+            boolean validCluster =
+                    instance.getCluster().equals("staging-service-a") ||
+                    instance.getCluster().equals("production-service-b");
+            assertThat(validCluster).isTrue();
+        }
+
+    }
+}

--- a/breakerbox-service/src/test/java/com/yammer/breakerbox/service/turbine/tests/KubernetesInstanceDiscoveryTest.java
+++ b/breakerbox-service/src/test/java/com/yammer/breakerbox/service/turbine/tests/KubernetesInstanceDiscoveryTest.java
@@ -3,13 +3,11 @@ package com.yammer.breakerbox.service.turbine.tests;
 import com.google.common.collect.Lists;
 import com.netflix.turbine.discovery.Instance;
 import com.yammer.breakerbox.service.turbine.KubernetesInstanceDiscovery;
-import io.fabric8.kubernetes.api.model.DoneableReplicationController;
-import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ReplicationController;
-import io.fabric8.kubernetes.api.model.ReplicationControllerList;
+import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.dsl.ClientMixedOperation;
-import io.fabric8.kubernetes.client.dsl.ClientRollableScallableResource;
+import io.fabric8.kubernetes.client.dsl.ClientPodResource;
+import org.assertj.core.util.Maps;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -17,44 +15,98 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.regex.Pattern;
 
-import static org.mockito.Mockito.stub;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.stub;
 
 @RunWith(MockitoJUnitRunner.class)
 public class KubernetesInstanceDiscoveryTest {
 
     @Mock DefaultKubernetesClient client;
-    @Mock ClientMixedOperation<
-            ReplicationController,
-            ReplicationControllerList,
-            DoneableReplicationController,
-            ClientRollableScallableResource<ReplicationController, DoneableReplicationController>> controllers;
-    @Mock ReplicationControllerList controllerList;
+    @Mock ClientMixedOperation<Pod, PodList, DoneablePod, ClientPodResource<Pod, DoneablePod>> podsOperation;
+    @Mock ClientMixedOperation<Pod, PodList, DoneablePod, ClientPodResource<Pod, DoneablePod>> podsAnyNsOperation;
+    @Mock PodList podList;
 
     private KubernetesInstanceDiscovery discovery;
 
     @Before
     public void setupDiscovery() {
-        ReplicationController serviceA = new ReplicationController();
-        serviceA.setMetadata(new ObjectMeta());
-        serviceA.getMetadata().setName("Service A");
-        serviceA.getMetadata().setNamespace("staging");
-        ReplicationController serviceB = new ReplicationController();
-        serviceB.setMetadata(new ObjectMeta());
-        serviceB.getMetadata().setName("Service B");
-        serviceB.getMetadata().setNamespace("production");
-        List<ReplicationController> list = Lists.newArrayList(serviceA, serviceB);
+        stub(client.pods()).toReturn(podsOperation);
+        stub(podsOperation.inAnyNamespace()).toReturn(podsAnyNsOperation);
+        stub(podsAnyNsOperation.list()).toReturn(podList);
 
-        stub(client.replicationControllers()).toReturn(controllers);
-        stub(controllers.list()).toReturn(controllerList);
-        stub(controllerList.getItems()).toReturn(list);
+        Pod serviceA1 = new Pod();
+        serviceA1.setMetadata(new ObjectMeta());
+        serviceA1.setStatus(new PodStatus());
+        serviceA1.getStatus().setPodIP("10.116.0.6");
+        serviceA1.getStatus().setPhase("Running");
+        serviceA1.getMetadata().setAnnotations(
+                Maps.newHashMap(KubernetesInstanceDiscovery.PORT_ANNOTATION_KEY, "8080"));
+        serviceA1.getMetadata().setName("service-a-67das7");
+        serviceA1.getMetadata().setGenerateName("service-a-");
+        serviceA1.getMetadata().setNamespace("staging");
+
+        Pod serviceA2 = new Pod();
+        serviceA2.setMetadata(new ObjectMeta());
+        serviceA2.setStatus(new PodStatus());
+        serviceA2.getStatus().setPodIP("10.116.0.7");
+        serviceA2.getStatus().setPhase("Running");
+        serviceA2.getMetadata().setAnnotations(
+                Maps.newHashMap(KubernetesInstanceDiscovery.PORT_ANNOTATION_KEY, "8080"));
+        serviceA2.getMetadata().setName("service-a-0889d23");
+        serviceA2.getMetadata().setGenerateName("service-a-");
+        serviceA2.getMetadata().setNamespace("staging");
+
+        Pod serviceB = new Pod();
+        serviceB.setMetadata(new ObjectMeta());
+        serviceB.setStatus(new PodStatus());
+        serviceB.getStatus().setPodIP("10.116.0.8");
+        serviceB.getStatus().setPhase("Running");
+        serviceB.getMetadata().setAnnotations(
+                Maps.newHashMap(KubernetesInstanceDiscovery.PORT_ANNOTATION_KEY, "80"));
+        serviceB.getMetadata().setName("service-b-097fsd");
+        serviceB.getMetadata().setGenerateName("service-b-");
+        serviceB.getMetadata().setNamespace("production");
+
+        // Should not be detected
+        Pod nonBreakerboxService = new Pod();
+        nonBreakerboxService.setMetadata(new ObjectMeta());
+        nonBreakerboxService.setStatus(new PodStatus());
+        nonBreakerboxService.getStatus().setPhase("Running");
+        nonBreakerboxService.getStatus().setPodIP("10.116.0.9");
+        nonBreakerboxService.getMetadata().setAnnotations(new HashMap<>());
+        nonBreakerboxService.getMetadata().setName("service-c-097900");
+        nonBreakerboxService.getMetadata().setGenerateName("service-c-");
+        nonBreakerboxService.getMetadata().setNamespace("production");
+        List<Pod> pods = Lists.newArrayList(serviceA1, serviceA2, serviceB, nonBreakerboxService);
+
+        stub(podList.getItems()).toReturn(pods);
         this.discovery = new KubernetesInstanceDiscovery(client);
     }
 
     @Test
-    public void usesControllerNamesToBuildClusters() throws Exception {
+    public void usesOnlyPodsWithPortAnnotation() throws Exception {
+        for (Instance instance: discovery.getInstanceList())
+            assertThat(instance.getCluster()).doesNotStartWith("production-service-c");
+    }
+
+    @Test
+    public void usesIpAddressForHostName() throws Exception {
+        for (Instance instance: discovery.getInstanceList())
+            assertThat(instance.getHostname())
+                    .matches(Pattern.compile("^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}:[0-9]{2,5}$"));
+    }
+
+    @Test
+    public void createsCorrectAmountOfInstances() throws Exception {
+        assertThat(discovery.getInstanceList().size()).isEqualTo(3);
+    }
+
+    @Test
+    public void usesPodGenerateNamesAndNamespaceToBuildClusters() throws Exception {
         Collection<Instance> instances = discovery.getInstanceList();
         for (Instance instance: instances) {
             boolean validCluster =
@@ -62,6 +114,15 @@ public class KubernetesInstanceDiscoveryTest {
                     instance.getCluster().equals("production-service-b");
             assertThat(validCluster).isTrue();
         }
+    }
 
+    @Test
+    public void onlyAcceptsCorrectValuesInPortAnnotation() {
+        // TODO: Only valid port values should be accepted
+    }
+
+    @Test
+    public void usesPhasePropertyAsInstanceStatus() {
+        // TODO: Mark instance as 'active' if pod phase is 'Running'
     }
 }


### PR DESCRIPTION
I created a class which will detect Kubernetes pods that are annotated with 'breakerbox-port'. This has two advantages:

1. The user can tell breakerbox which pods are running a breakerbox-enabled service
2. The user can define which port the turbine endpoints are running on

It will cluster the instances with a combination of the namespace and the pod's base name and use the pod's IP address as the host name. 
However, I am unsure how to properly integrate it into the breakerbox service without breaking existing configurations.