### PR TITLE
Adding MySQL suppport into breakerbox.

### DIFF
--- a/breakerbox-jdbi/pom.xml
+++ b/breakerbox-jdbi/pom.xml
@@ -15,6 +15,10 @@
             <artifactId>postgresql</artifactId>
         </dependency>
         <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.yammer.breakerbox</groupId>
             <artifactId>breakerbox-store</artifactId>
         </dependency>

--- a/breakerbox-jdbi/src/main/resources/migrations/dependency.xml
+++ b/breakerbox-jdbi/src/main/resources/migrations/dependency.xml
@@ -3,12 +3,16 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+    <!-- Defining this database driven property as MySQL has a constraint while creating indexes on VARCHAR columns
+    Refer: https://stackoverflow.com/questions/15157227/mysql-varchar-index-length -->
+    <property name="name.type" value="varchar(1024)" dbms="h2,postgresql"/>
+    <property name="name.type" value="varchar(255)" dbms="mysql"/>
     <changeSet id="1" author="chrisgray">
         <createTable tableName="dependency">
             <column name="id" type="int" autoIncrement="true">
                 <constraints primaryKey="true" nullable="false"/>
             </column>
-            <column name="name" type="varchar(1024)">
+            <column name="name" type="${name.type}">
                 <constraints nullable="false"/>
             </column>
             <column name="timestamp" type="bigint">

--- a/breakerbox-jdbi/src/main/resources/migrations/service.xml
+++ b/breakerbox-jdbi/src/main/resources/migrations/service.xml
@@ -3,15 +3,21 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+    <!-- Defining these database driven properties as MySQL has a constraint while creating indexes on VARCHAR columns
+    Refer: https://stackoverflow.com/questions/15157227/mysql-varchar-index-length -->
+    <property name="name.type" value="varchar(1024)" dbms="h2,postgresql"/>
+    <property name="name.type" value="varchar(255)" dbms="mysql"/>
+    <property name="dependency.type" value="varchar(1024)" dbms="h2,postgresql"/>
+    <property name="dependency.type" value="varchar(255)" dbms="mysql"/>
     <changeSet id="1" author="chrisgray">
         <createTable tableName="service">
             <column name="id" type="int" autoIncrement="true">
                 <constraints primaryKey="true" nullable="false"/>
             </column>
-            <column name="name" type="varchar(1024)">
+            <column name="name" type="${name.type}">
                 <constraints nullable="false"/>
             </column>
-            <column name="dependency" type="varchar(1024)">
+            <column name="dependency" type="${dependency.type}">
                 <constraints nullable="false"/>
             </column>
         </createTable>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <turbine.version>1.0.0</turbine.version>
         <dropwizard-auth-ldap.version>1.0.4</dropwizard-auth-ldap.version>
         <postgresql.version>42.1.1</postgresql.version>
+        <mysql.version>5.1.38</mysql.version>
         <h2.version>1.4.195</h2.version>
         <kubernetes.version>2.2.144</kubernetes.version>
         <mockito-core.version>2.8.9</mockito-core.version>
@@ -104,6 +105,11 @@
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
                 <version>${postgresql.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>mysql</groupId>
+                <artifactId>mysql-connector-java</artifactId>
+                <version>${mysql.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.h2database</groupId>


### PR DESCRIPTION
Hi,

In this PR, i have added mysql support into breakerbox.

Summary of changes:

1) Added MySQL jdbc driver dependency.
2) Tweaked the liquibase migration xml's to handle MySQL (details in this link: https://stackoverflow.com/questions/15157227/mysql-varchar-index-length)

Let me know if this looks good!

Thanks. 