### PR TITLE
Custom path for hystrix metrics stream in case of Rancher discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ defaultDashboard: production
 
 instanceDiscoveryClass: com.yammer.breakerbox.turbine.YamlInstanceDiscovery #default
 
+hystrixStreamSuffix: /tenacity/metrics.stream #default
+
 metaClusters: 
   - production
   - stage
@@ -200,8 +202,10 @@ To integrate with RancherInstanceDiscovery,
          a. tenacity.metrics.stream.enabled: true
          b. tenacity.metrics.stream.port: 8080
          c. service.cluster.name: clusterName
+    
+    3. Use hystrixStreamSuffix to provide custom path for hystrix metrics stream. It defaults to /tenacity/metrics.stream
         
-    3. RancherInstanceDiscovery will create dashboards per service-cluster with service.cluster.name label and one aggregated production dashboard. Dashboards can be created, enabled, disabled by updating labels at runtime.
+    4. RancherInstanceDiscovery will create dashboards per service-cluster with service.cluster.name label and one aggregated production dashboard. Dashboards can be created, enabled, disabled by updating labels at runtime.
 
 To integrate with MarathonInstanceDiscovery,
     1. specify marathon services Api url, marathonAppPort(your application port), marathonAppNameSpace and clusterName.

--- a/breakerbox-service/src/main/java/com/yammer/breakerbox/service/BreakerboxService.java
+++ b/breakerbox-service/src/main/java/com/yammer/breakerbox/service/BreakerboxService.java
@@ -225,8 +225,13 @@ public class BreakerboxService extends Application<BreakerboxServiceConfiguratio
                                                Environment environment) {
         final Optional<InstanceDiscovery> customInstanceDiscovery = createInstanceDiscovery(configuration, environment);
         if (customInstanceDiscovery.isPresent()) {
-            PluginsFactory.setInstanceDiscovery(RegisterClustersInstanceDiscoveryWrapper.wrap(
-                    customInstanceDiscovery.get()));
+            if(configuration.getHystrixStreamSuffix().isPresent()){
+                PluginsFactory.setInstanceDiscovery(RegisterClustersInstanceDiscoveryWrapper.wrap(
+                        customInstanceDiscovery.get(),configuration.getHystrixStreamSuffix().get()));
+            } else {
+                PluginsFactory.setInstanceDiscovery(RegisterClustersInstanceDiscoveryWrapper.wrap(
+                        customInstanceDiscovery.get()));
+            }
         } else {
             final YamlInstanceDiscovery yamlInstanceDiscovery = new YamlInstanceDiscovery(
                     configuration.getTurbine(), environment.getValidator(), environment.getObjectMapper());

--- a/breakerbox-service/src/main/java/com/yammer/breakerbox/service/BreakerboxService.java
+++ b/breakerbox-service/src/main/java/com/yammer/breakerbox/service/BreakerboxService.java
@@ -46,6 +46,8 @@ import io.dropwizard.auth.AuthValueFactoryProvider;
 import io.dropwizard.auth.CachingAuthenticator;
 import io.dropwizard.auth.basic.BasicCredentialAuthFilter;
 import io.dropwizard.auth.basic.BasicCredentials;
+import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
+import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.jdbi.bundles.DBIExceptionsBundle;
 import io.dropwizard.migrations.MigrationsBundle;
@@ -73,6 +75,8 @@ public class BreakerboxService extends Application<BreakerboxServiceConfiguratio
 
     @Override
     public void initialize(Bootstrap<BreakerboxServiceConfiguration> bootstrap) {
+        bootstrap.setConfigurationSourceProvider(new SubstitutingSourceProvider(
+                bootstrap.getConfigurationSourceProvider(), new EnvironmentVariableSubstitutor(false)));
         bootstrap.addBundle(new DBIExceptionsBundle());
         bootstrap.addBundle(new MigrationsBundle<BreakerboxServiceConfiguration>() {
             @Override

--- a/breakerbox-service/src/main/java/com/yammer/breakerbox/service/config/BreakerboxServiceConfiguration.java
+++ b/breakerbox-service/src/main/java/com/yammer/breakerbox/service/config/BreakerboxServiceConfiguration.java
@@ -64,6 +64,9 @@ public class BreakerboxServiceConfiguration extends Configuration {
     private Optional<String> instanceDiscoveryClass;
 
     @NotNull @UnwrapValidatedValue(false)
+    private Optional<String> hystrixStreamSuffix;
+
+    @NotNull @UnwrapValidatedValue(false)
     private final Optional<RancherInstanceConfiguration> rancherInstanceConfiguration;
 
     @NotNull @UnwrapValidatedValue(false)
@@ -82,6 +85,7 @@ public class BreakerboxServiceConfiguration extends Configuration {
                                           @JsonProperty("defaultDashboard") String defaultDashboard,
                                           @JsonProperty("turbine") Path turbine,
                                           @JsonProperty("instanceDiscoveryClass") String instanceDiscoveryClass,
+                                          @JsonProperty("hystrixStreamSuffix") String hystrixStreamSuffix,
                                           @JsonProperty("rancherDiscovery") RancherInstanceConfiguration rancherInstanceConfiguration,
                                           @JsonProperty("marathonDiscovery")List<MarathonClientConfiguration> marathonClientConfiguration) {
         this.azure = Optional.fromNullable(azure);
@@ -97,6 +101,7 @@ public class BreakerboxServiceConfiguration extends Configuration {
         this.turbine = Optional.fromNullable(turbine).or(Paths.get("breakerbox-instances.yml"));
         this.instanceDiscoveryClass = Optional.fromNullable(instanceDiscoveryClass)
                 .or(Optional.fromNullable(System.getProperty("InstanceDiscovery.impl")));
+        this.hystrixStreamSuffix = Optional.fromNullable(hystrixStreamSuffix);
         this.rancherInstanceConfiguration = Optional.fromNullable(rancherInstanceConfiguration);
         this.marathonClientConfiguration = Optional.fromNullable(marathonClientConfiguration);
     }
@@ -165,6 +170,10 @@ public class BreakerboxServiceConfiguration extends Configuration {
 
     public Optional<String> getInstanceDiscoveryClass() {
         return instanceDiscoveryClass;
+    }
+
+    public Optional<String> getHystrixStreamSuffix() {
+        return hystrixStreamSuffix;
     }
 
     public void setInstanceDiscoveryClass(String instanceDiscoveryClass) {


### PR DESCRIPTION
In case of Rancher discovery there is no way to override the default path for hystrix metrics stream (/tenacity/metrics.stream). This pull request has minor changes that help to override the default path for metrics stream in breakerbox.yml